### PR TITLE
使用 ToUpperInvariant 替换 ToUpper，这能提升大量性能

### DIFF
--- a/src/dotnetCampus.CommandLine/CommandLine.cs
+++ b/src/dotnetCampus.CommandLine/CommandLine.cs
@@ -358,7 +358,7 @@ namespace dotnetCampus.Cli
                 return $"-{option}";
             }
 
-            chars[0] = char.ToUpper(chars[0], CultureInfo.InvariantCulture);
+            chars[0] = char.ToUpperInvariant(chars[0]);
             return $"-{new string(chars)}";
         }
 
@@ -381,7 +381,7 @@ namespace dotnetCampus.Cli
                 else if (isWordFirstLetter)
                 {
                     isWordFirstLetter = false;
-                    builder.Append(char.ToUpper(current, CultureInfo.InvariantCulture));
+                    builder.Append(char.ToUpperInvariant(current));
                 }
                 else
                 {


### PR DESCRIPTION
虽然仅初始化时执行一次，但花了 10ms

![image](https://github.com/dotnet-campus/dotnetCampus.CommandLine/assets/9959623/0520cd33-0e50-45df-8354-1dcdf23c758f)
