### PR TITLE
允许在命令行类型中填充原始参数 + 仅 Windows 下才支持斜杠命令行选项

### DIFF
--- a/samples/DotNetCampus.CommandLine.Sample/DefaultOptions.cs
+++ b/samples/DotNetCampus.CommandLine.Sample/DefaultOptions.cs
@@ -7,6 +7,9 @@ namespace DotNetCampus.Cli;
 
 internal class DefaultOptions
 {
+    [RawArguments]
+    public required string[] MainArgs { get; init; }
+
     [Option(LocalizableDescription = nameof(LocalizableStrings.SamplePropertyDescription))]
     public string? DefaultText { get; set; }
 

--- a/src/DotNetCampus.CommandLine.Analyzer/AnalyzerReleases.Shipped.md
+++ b/src/DotNetCampus.CommandLine.Analyzer/AnalyzerReleases.Shipped.md
@@ -9,6 +9,7 @@ Rule ID | Category | Severity | Notes
 DCL101 | DotNetCampus.AvoidBugs | Warning | <https://github.com/dotnet-campus/DotNetCampus.CommandLine/blob/main/docs/analyzers/DCL101.md>
 DCL201 | DotNetCampus.CodeFixOnly | Hidden | <https://github.com/dotnet-campus/DotNetCampus.CommandLine/blob/main/docs/analyzers/DCL201.md>
 DCL202 | DotNetCampus.RuntimeException | Error | <https://github.com/dotnet-campus/DotNetCampus.CommandLine/blob/main/docs/analyzers/DCL202.md>
+DCL203 | DotNetCampus.Mechanism | Error | <https://github.com/dotnet-campus/DotNetCampus.CommandLine/blob/main/docs/analyzers/DCL203.md>
 
 ## Release 3.2
 

--- a/src/DotNetCampus.CommandLine.Analyzer/Analyzers/FindOptionPropertyTypeAnalyzer.cs
+++ b/src/DotNetCampus.CommandLine.Analyzer/Analyzers/FindOptionPropertyTypeAnalyzer.cs
@@ -9,22 +9,27 @@ namespace DotNetCampus.CommandLine.Analyzers;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class FindOptionPropertyTypeAnalyzer : DiagnosticAnalyzer
 {
-    private readonly ImmutableHashSet<string> _nonGenericTypeNames =
+    private readonly HashSet<string> _nonGenericTypeNames =
     [
         "String", "string", "Boolean", "bool", "Byte", "byte", "Int16", "short", "UInt16", "ushort", "Int32", "int", "UInt32", "uint", "Int64", "long",
         "UInt64", "ulong", "Single", "float", "Double", "double", "Decimal", "decimal", "IList", "ICollection", "IEnumerable",
     ];
 
-    private readonly ImmutableHashSet<string> _oneGenericTypeNames =
+    private readonly HashSet<string> _oneGenericTypeNames =
     [
         "[]", "ImmutableArray", "List", "IList", "IReadOnlyList", "ImmutableHashSet", "Collection", "ICollection", "IReadOnlyCollection", "IEnumerable",
     ];
 
-    private readonly ImmutableHashSet<string> _twoGenericTypeNames =
+    private readonly HashSet<string> _rawArgumentsGenericTypeNames =
+    [
+        "[]", "IList", "IReadOnlyList", "ICollection", "IReadOnlyCollection", "IEnumerable",
+    ];
+
+    private readonly HashSet<string> _twoGenericTypeNames =
         ["ImmutableDictionary", "Dictionary", "IDictionary", "IReadOnlyDictionary", "KeyValuePair"];
 
-    private readonly ImmutableHashSet<string> _genericKeyArgumentTypeNames = ["String", "string"];
-    private readonly ImmutableHashSet<string> _genericArgumentTypeNames = ["String", "string"];
+    private readonly HashSet<string> _genericKeyArgumentTypeNames = ["String", "string"];
+    private readonly HashSet<string> _genericArgumentTypeNames = ["String", "string"];
 
     /// <summary>
     /// Supported diagnostics.
@@ -182,7 +187,7 @@ public class FindOptionPropertyTypeAnalyzer : DiagnosticAnalyzer
         string typeName = GetTypeName(propertyTypeSyntax);
         var (genericType0, genericType1) = GetGenericTypeNames(propertyTypeSyntax);
 
-        if (IsOneGenericType(typeName)
+        if (IsRawArgumentsGenericType(typeName)
             && genericType0 != null
             && IsGenericArgumentType(genericType0))
         {
@@ -264,6 +269,9 @@ public class FindOptionPropertyTypeAnalyzer : DiagnosticAnalyzer
 
     private bool IsOneGenericType(string typeName)
         => _oneGenericTypeNames.Contains(typeName, StringComparer.Ordinal);
+
+    private bool IsRawArgumentsGenericType(string typeName)
+        => _rawArgumentsGenericTypeNames.Contains(typeName, StringComparer.Ordinal);
 
     private bool IsTwoGenericType(string typeName)
         => _twoGenericTypeNames.Contains(typeName, StringComparer.Ordinal);

--- a/src/DotNetCampus.CommandLine.Analyzer/Analyzers/FindOptionPropertyTypeAnalyzer.cs
+++ b/src/DotNetCampus.CommandLine.Analyzer/Analyzers/FindOptionPropertyTypeAnalyzer.cs
@@ -4,7 +4,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
-namespace DotNetCampus.CommandLine.Analyzers.ConvertOptionProperty;
+namespace DotNetCampus.CommandLine.Analyzers;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class FindOptionPropertyTypeAnalyzer : DiagnosticAnalyzer

--- a/src/DotNetCampus.CommandLine.Analyzer/CodeFixes/ConvertOptionProperty/ConvertOptionPropertyTypeCodeFix.cs
+++ b/src/DotNetCampus.CommandLine.Analyzer/CodeFixes/ConvertOptionProperty/ConvertOptionPropertyTypeCodeFix.cs
@@ -3,7 +3,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace DotNetCampus.CommandLine.Analyzers.ConvertOptionProperty;
+namespace DotNetCampus.CommandLine.CodeFixes.ConvertOptionProperty;
 
 public abstract class ConvertOptionPropertyTypeCodeFix : CodeFixProvider
 {

--- a/src/DotNetCampus.CommandLine.Analyzer/CodeFixes/ConvertOptionProperty/OptionPropertyTypeToBooleanCodeFix.cs
+++ b/src/DotNetCampus.CommandLine.Analyzer/CodeFixes/ConvertOptionProperty/OptionPropertyTypeToBooleanCodeFix.cs
@@ -6,10 +6,10 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace DotNetCampus.CommandLine.Analyzers.ConvertOptionProperty;
+namespace DotNetCampus.CommandLine.CodeFixes.ConvertOptionProperty;
 
-[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(OptionPropertyTypeToStringCodeFix)), Shared]
-public class OptionPropertyTypeToStringCodeFix : ConvertOptionPropertyTypeCodeFix
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(OptionPropertyTypeToBooleanCodeFix)), Shared]
+public class OptionPropertyTypeToBooleanCodeFix : ConvertOptionPropertyTypeCodeFix
 {
     public sealed override ImmutableArray<string> FixableDiagnosticIds =>
     [
@@ -17,7 +17,7 @@ public class OptionPropertyTypeToStringCodeFix : ConvertOptionPropertyTypeCodeFi
         Diagnostics.NotSupportedOptionPropertyType,
     ];
 
-    protected sealed override string CodeActionTitle => Localizations.DCL201_202_Fix_OptionTypeToString;
+    protected sealed override string CodeActionTitle => Localizations.DCL201_202_Fix_OptionTypeToBoolean;
 
     protected sealed override CompilationUnitSyntax CreateTypeSyntaxNode(
         TypeSyntax oldTypeSyntax, CompilationUnitSyntax syntaxRoot, SemanticModel semanticModel,
@@ -26,6 +26,6 @@ public class OptionPropertyTypeToStringCodeFix : ConvertOptionPropertyTypeCodeFi
         return syntaxRoot.ReplaceNode(
             oldTypeSyntax,
             SyntaxFactory.PredefinedType(
-                SyntaxFactory.Token(SyntaxKind.StringKeyword)));
+                SyntaxFactory.Token(SyntaxKind.BoolKeyword)));
     }
 }

--- a/src/DotNetCampus.CommandLine.Analyzer/CodeFixes/ConvertOptionProperty/OptionPropertyTypeToDictionaryCodeFix.cs
+++ b/src/DotNetCampus.CommandLine.Analyzer/CodeFixes/ConvertOptionProperty/OptionPropertyTypeToDictionaryCodeFix.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Simplification;
 
-namespace DotNetCampus.CommandLine.Analyzers.ConvertOptionProperty;
+namespace DotNetCampus.CommandLine.CodeFixes.ConvertOptionProperty;
 
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(OptionPropertyTypeToDictionaryCodeFix)), Shared]
 public class OptionPropertyTypeToDictionaryCodeFix : ConvertOptionPropertyTypeCodeFix

--- a/src/DotNetCampus.CommandLine.Analyzer/CodeFixes/ConvertOptionProperty/OptionPropertyTypeToDoubleCodeFix.cs
+++ b/src/DotNetCampus.CommandLine.Analyzer/CodeFixes/ConvertOptionProperty/OptionPropertyTypeToDoubleCodeFix.cs
@@ -5,12 +5,11 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Simplification;
 
-namespace DotNetCampus.CommandLine.Analyzers.ConvertOptionProperty;
+namespace DotNetCampus.CommandLine.CodeFixes.ConvertOptionProperty;
 
-[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(OptionPropertyTypeToListCodeFix)), Shared]
-public class OptionPropertyTypeToListCodeFix : ConvertOptionPropertyTypeCodeFix
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(OptionPropertyTypeToDoubleCodeFix)), Shared]
+public class OptionPropertyTypeToDoubleCodeFix : ConvertOptionPropertyTypeCodeFix
 {
     public sealed override ImmutableArray<string> FixableDiagnosticIds =>
     [
@@ -18,7 +17,7 @@ public class OptionPropertyTypeToListCodeFix : ConvertOptionPropertyTypeCodeFix
         Diagnostics.NotSupportedOptionPropertyType,
     ];
 
-    protected sealed override string CodeActionTitle => Localizations.DCL201_202_Fix_OptionTypeToList;
+    protected sealed override string CodeActionTitle => Localizations.DCL201_202_Fix_OptionTypeToDouble;
 
     protected sealed override CompilationUnitSyntax CreateTypeSyntaxNode(
         TypeSyntax oldTypeSyntax, CompilationUnitSyntax syntaxRoot, SemanticModel semanticModel,
@@ -26,7 +25,7 @@ public class OptionPropertyTypeToListCodeFix : ConvertOptionPropertyTypeCodeFix
     {
         return syntaxRoot.ReplaceNode(
             oldTypeSyntax,
-            SyntaxFactory.ParseName("global::System.Collections.Generic.IReadOnlyList<string>")
-                .WithAdditionalAnnotations(Simplifier.Annotation));
+            SyntaxFactory.PredefinedType(
+                SyntaxFactory.Token(SyntaxKind.DoubleKeyword)));
     }
 }

--- a/src/DotNetCampus.CommandLine.Analyzer/CodeFixes/ConvertOptionProperty/OptionPropertyTypeToInt32CodeFix.cs
+++ b/src/DotNetCampus.CommandLine.Analyzer/CodeFixes/ConvertOptionProperty/OptionPropertyTypeToInt32CodeFix.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace DotNetCampus.CommandLine.Analyzers.ConvertOptionProperty;
+namespace DotNetCampus.CommandLine.CodeFixes.ConvertOptionProperty;
 
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(OptionPropertyTypeToInt32CodeFix)), Shared]
 public class OptionPropertyTypeToInt32CodeFix : ConvertOptionPropertyTypeCodeFix

--- a/src/DotNetCampus.CommandLine.Analyzer/CodeFixes/ConvertOptionProperty/OptionPropertyTypeToListCodeFix.cs
+++ b/src/DotNetCampus.CommandLine.Analyzer/CodeFixes/ConvertOptionProperty/OptionPropertyTypeToListCodeFix.cs
@@ -5,11 +5,12 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Simplification;
 
-namespace DotNetCampus.CommandLine.Analyzers.ConvertOptionProperty;
+namespace DotNetCampus.CommandLine.CodeFixes.ConvertOptionProperty;
 
-[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(OptionPropertyTypeToBooleanCodeFix)), Shared]
-public class OptionPropertyTypeToBooleanCodeFix : ConvertOptionPropertyTypeCodeFix
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(OptionPropertyTypeToListCodeFix)), Shared]
+public class OptionPropertyTypeToListCodeFix : ConvertOptionPropertyTypeCodeFix
 {
     public sealed override ImmutableArray<string> FixableDiagnosticIds =>
     [
@@ -17,7 +18,7 @@ public class OptionPropertyTypeToBooleanCodeFix : ConvertOptionPropertyTypeCodeF
         Diagnostics.NotSupportedOptionPropertyType,
     ];
 
-    protected sealed override string CodeActionTitle => Localizations.DCL201_202_Fix_OptionTypeToBoolean;
+    protected sealed override string CodeActionTitle => Localizations.DCL201_202_Fix_OptionTypeToList;
 
     protected sealed override CompilationUnitSyntax CreateTypeSyntaxNode(
         TypeSyntax oldTypeSyntax, CompilationUnitSyntax syntaxRoot, SemanticModel semanticModel,
@@ -25,7 +26,7 @@ public class OptionPropertyTypeToBooleanCodeFix : ConvertOptionPropertyTypeCodeF
     {
         return syntaxRoot.ReplaceNode(
             oldTypeSyntax,
-            SyntaxFactory.PredefinedType(
-                SyntaxFactory.Token(SyntaxKind.BoolKeyword)));
+            SyntaxFactory.ParseName("global::System.Collections.Generic.IReadOnlyList<string>")
+                .WithAdditionalAnnotations(Simplifier.Annotation));
     }
 }

--- a/src/DotNetCampus.CommandLine.Analyzer/CodeFixes/ConvertOptionProperty/OptionPropertyTypeToStringCodeFix.cs
+++ b/src/DotNetCampus.CommandLine.Analyzer/CodeFixes/ConvertOptionProperty/OptionPropertyTypeToStringCodeFix.cs
@@ -6,10 +6,10 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace DotNetCampus.CommandLine.Analyzers.ConvertOptionProperty;
+namespace DotNetCampus.CommandLine.CodeFixes.ConvertOptionProperty;
 
-[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(OptionPropertyTypeToDoubleCodeFix)), Shared]
-public class OptionPropertyTypeToDoubleCodeFix : ConvertOptionPropertyTypeCodeFix
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(OptionPropertyTypeToStringCodeFix)), Shared]
+public class OptionPropertyTypeToStringCodeFix : ConvertOptionPropertyTypeCodeFix
 {
     public sealed override ImmutableArray<string> FixableDiagnosticIds =>
     [
@@ -17,7 +17,7 @@ public class OptionPropertyTypeToDoubleCodeFix : ConvertOptionPropertyTypeCodeFi
         Diagnostics.NotSupportedOptionPropertyType,
     ];
 
-    protected sealed override string CodeActionTitle => Localizations.DCL201_202_Fix_OptionTypeToDouble;
+    protected sealed override string CodeActionTitle => Localizations.DCL201_202_Fix_OptionTypeToString;
 
     protected sealed override CompilationUnitSyntax CreateTypeSyntaxNode(
         TypeSyntax oldTypeSyntax, CompilationUnitSyntax syntaxRoot, SemanticModel semanticModel,
@@ -26,6 +26,6 @@ public class OptionPropertyTypeToDoubleCodeFix : ConvertOptionPropertyTypeCodeFi
         return syntaxRoot.ReplaceNode(
             oldTypeSyntax,
             SyntaxFactory.PredefinedType(
-                SyntaxFactory.Token(SyntaxKind.DoubleKeyword)));
+                SyntaxFactory.Token(SyntaxKind.StringKeyword)));
     }
 }

--- a/src/DotNetCampus.CommandLine.Analyzer/CodeFixes/OptionLongNameMustBeKebabCaseCodeFixProvider.cs
+++ b/src/DotNetCampus.CommandLine.Analyzer/CodeFixes/OptionLongNameMustBeKebabCaseCodeFixProvider.cs
@@ -1,14 +1,14 @@
 using System.Collections.Immutable;
 using System.Composition;
+using DotNetCampus.Cli.Utils;
+using DotNetCampus.CommandLine.Properties;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using DotNetCampus.CommandLine.Properties;
-using DotNetCampus.Cli.Utils;
 
-namespace DotNetCampus.CommandLine.Analyzers;
+namespace DotNetCampus.CommandLine.CodeFixes;
 
 /// <summary>
 /// [Option("LongName")]

--- a/src/DotNetCampus.CommandLine.Analyzer/Diagnostics.cs
+++ b/src/DotNetCampus.CommandLine.Analyzer/Diagnostics.cs
@@ -44,11 +44,22 @@ public static class Diagnostics
         description: Localize(nameof(DCL202_Description)),
         helpLinkUri: Url(NotSupportedOptionPropertyType));
 
+    public static readonly DiagnosticDescriptor DCL203_NotSupportedRawArgumentsPropertyType = new DiagnosticDescriptor(
+        nameof(DCL203),
+        Localize(nameof(DCL203)),
+        Localize(nameof(DCL203_Message)),
+        Categories.Mechanism,
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: Localize(nameof(DCL203_Description)),
+        helpLinkUri: Url(NotSupportedRawArgumentsPropertyType));
+
     #endregion
 
     public const string OptionLongNameMustBeKebabCase = "DCL101";
     public const string SupportedOptionPropertyType = "DCL201";
     public const string NotSupportedOptionPropertyType = "DCL202";
+    public const string NotSupportedRawArgumentsPropertyType = "DCL203";
 
     private static class Categories
     {

--- a/src/DotNetCampus.CommandLine.Analyzer/Generators/BuilderGenerator.cs
+++ b/src/DotNetCampus.CommandLine.Analyzer/Generators/BuilderGenerator.cs
@@ -198,7 +198,7 @@ internal sealed class {{model.GetBuilderTypeName()}}
         }
     }
 
-    private string GenerateRawArgumentsPropertyAssignment(RawArgumentsPropertyGeneratingModel property, int modelIndex)
+    private string GenerateRawArgumentsPropertyAssignment(RawArgumentsPropertyGeneratingModel property)
     {
         var isInitProperty = property.IsRequired || property.IsInitOnly;
         if (isInitProperty)

--- a/src/DotNetCampus.CommandLine.Analyzer/Generators/ModelProviding/CommandModelProvider.cs
+++ b/src/DotNetCampus.CommandLine.Analyzer/Generators/ModelProviding/CommandModelProvider.cs
@@ -61,7 +61,7 @@ internal static class CommandModelProvider
                 var rawArgumentsProperties = typeSymbol
                     .GetAttributedProperties(RawArgumentsPropertyGeneratingModel.TryParse);
 
-                if (!isOptions && !isHandler && attribute is null && optionProperties.IsEmpty && valueProperties.IsEmpty)
+                if (!isOptions && !isHandler && attribute is null && optionProperties.IsEmpty && valueProperties.IsEmpty && rawArgumentsProperties.IsEmpty)
                 {
                     // 不是命令行选项类型。
                     return null;

--- a/src/DotNetCampus.CommandLine.Analyzer/Generators/ModelProviding/CommandModelProvider.cs
+++ b/src/DotNetCampus.CommandLine.Analyzer/Generators/ModelProviding/CommandModelProvider.cs
@@ -40,6 +40,7 @@ internal static class CommandModelProvider
                 // 3. 拥有 [Verb] 特性
                 // 4. 拥有 [Option] 特性的属性
                 // 5. 拥有 [Value] 特性的属性
+                // 6. 拥有 [RawArguments] 特性的属性
 
                 // 1. 实现 ICommandOptions 接口。
                 var isOptions = typeSymbol.AllInterfaces.Any(i =>
@@ -52,26 +53,13 @@ internal static class CommandModelProvider
                     .FirstOrDefault(a => a.AttributeClass!.IsAttributeOf<VerbAttribute>());
                 // 4. 拥有 [Option] 特性的属性。
                 var optionProperties = typeSymbol
-                    .EnumerateBaseTypesRecursively()                                            // 递归获取所有基类
-                    .Reverse()                                                                  // （注意我们先给父类属性赋值，再给子类属性赋值）
-                    .SelectMany(x => x.GetMembers())                              //                 的所有成员，
-                    .OfType<IPropertySymbol>()                                                  //                             然后取出属性，
-                    .Select(OptionPropertyGeneratingModel.TryParse)                             // 解析出 OptionPropertyGeneratingModel。
-                    .OfType<OptionPropertyGeneratingModel>()
-                    .GroupBy(x => x.PropertyName)              // 按属性名去重。
-                    .Select(x => x.Last())  // 随后，取子类的属性（去除父类的重名属性）。
-                    .ToImmutableArray();
+                    .GetAttributedProperties(OptionPropertyGeneratingModel.TryParse);
                 // 5. 拥有 [Value] 特性的属性。
                 var valueProperties = typeSymbol
-                    .EnumerateBaseTypesRecursively()                                            // 递归获取所有基类
-                    .Reverse()                                                                  // （注意我们先给父类属性赋值，再给子类属性赋值）
-                    .SelectMany(x => x.GetMembers())                              //                 的所有成员，
-                    .OfType<IPropertySymbol>()                                                  //                             然后取出属性，
-                    .Select(ValuePropertyGeneratingModel.TryParse)                              // 解析出 ValuePropertyGeneratingModel。
-                    .OfType<ValuePropertyGeneratingModel>()
-                    .GroupBy(x => x.PropertyName)               // 按属性名去重。
-                    .Select(x => x.Last())   // 随后，取子类的属性（去除父类的重名属性）。
-                    .ToImmutableArray();
+                    .GetAttributedProperties(ValuePropertyGeneratingModel.TryParse);
+                // 6. 拥有 [RawArguments] 特性的属性。
+                var rawArgumentsProperties = typeSymbol
+                    .GetAttributedProperties(RawArgumentsPropertyGeneratingModel.TryParse);
 
                 if (!isOptions && !isHandler && attribute is null && optionProperties.IsEmpty && valueProperties.IsEmpty)
                 {
@@ -90,6 +78,7 @@ internal static class CommandModelProvider
                     IsHandler = isHandler,
                     OptionProperties = optionProperties,
                     ValueProperties = valueProperties,
+                    RawArgumentsProperties = rawArgumentsProperties,
                 };
             })
             .Where(m => m is not null)
@@ -139,6 +128,8 @@ internal record CommandObjectGeneratingModel
     public required ImmutableArray<OptionPropertyGeneratingModel> OptionProperties { get; init; }
 
     public required ImmutableArray<ValuePropertyGeneratingModel> ValueProperties { get; init; }
+
+    public required ImmutableArray<RawArgumentsPropertyGeneratingModel> RawArgumentsProperties { get; init; }
 
     public string GetBuilderTypeName() => GetBuilderTypeName(CommandObjectType);
 
@@ -334,6 +325,37 @@ internal record ValuePropertyGeneratingModel
     }
 }
 
+internal record RawArgumentsPropertyGeneratingModel
+{
+    public required string PropertyName { get; init; }
+
+    public required ITypeSymbol Type { get; init; }
+
+    public required bool IsRequired { get; init; }
+
+    public required bool IsInitOnly { get; init; }
+
+    public required bool IsNullable { get; init; }
+
+    public static RawArgumentsPropertyGeneratingModel? TryParse(IPropertySymbol propertySymbol)
+    {
+        var rawArgumentsAttribute = propertySymbol.GetAttributes().FirstOrDefault(a => a.AttributeClass!.IsAttributeOf<RawArgumentsAttribute>());
+        if (rawArgumentsAttribute is null)
+        {
+            return null;
+        }
+
+        return new RawArgumentsPropertyGeneratingModel
+        {
+            PropertyName = propertySymbol.Name,
+            Type = propertySymbol.Type,
+            IsRequired = propertySymbol.IsRequired,
+            IsInitOnly = propertySymbol.SetMethod?.IsInitOnly ?? false,
+            IsNullable = propertySymbol.Type.NullableAnnotation == NullableAnnotation.Annotated,
+        };
+    }
+}
+
 internal record AssemblyCommandsGeneratingModel
 {
     public required string Namespace { get; init; }
@@ -351,5 +373,22 @@ file static class Extensions
             yield return current;
             current = current.BaseType;
         }
+    }
+
+    public static ImmutableArray<TModel> GetAttributedProperties<TModel>(this ITypeSymbol typeSymbol,
+        Func<IPropertySymbol, TModel?> propertyParser)
+        where TModel : class
+    {
+        return typeSymbol
+            .EnumerateBaseTypesRecursively()                                                 // 递归获取所有基类
+            .Reverse()                                                                       // （注意我们先给父类属性赋值，再给子类属性赋值）
+            .SelectMany(x => x.GetMembers())                                   //                 的所有成员，
+            .OfType<IPropertySymbol>()                                                       //                             然后取出属性，
+            .Select(x => (PropertyName: x.Name, Model: propertyParser(x))) // 解析出 OptionPropertyGeneratingModel。
+            .Where(x => x.Model is not null)
+            .GroupBy(x => x.PropertyName)                            // 按属性名去重。
+            .Select(x => x.Last().Model)           // 随后，取子类的属性（去除父类的重名属性）。
+            .Cast<TModel>()
+            .ToImmutableArray();
     }
 }

--- a/src/DotNetCampus.CommandLine.Analyzer/Properties/Localizations.Designer.cs
+++ b/src/DotNetCampus.CommandLine.Analyzer/Properties/Localizations.Designer.cs
@@ -177,7 +177,7 @@ namespace DotNetCampus.CommandLine.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Not supported property type.
+        ///   Looks up a localized string similar to Not supported command-line property type.
         /// </summary>
         public static string DCL202 {
             get {
@@ -186,7 +186,7 @@ namespace DotNetCampus.CommandLine.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This property has the type &apos;{0}&apos; which is not built-in supported. It&apos;s recommended to use bool/string/IReadOnlyList&lt;string&gt; or other types that the code fix will suggest you change instead or add a custom converter on your Value or Option attribute..
+        ///   Looks up a localized string similar to As a command-line option, the property type &apos;{0}&apos; is not supported. It is recommended to use bool/string/IReadOnlyList&lt;string&gt; or another type that the code fix may suggest, or add a custom converter on your Value or Option attribute..
         /// </summary>
         public static string DCL202_Description {
             get {
@@ -195,11 +195,38 @@ namespace DotNetCampus.CommandLine.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This property has the type &apos;{0}&apos; which is not built-in supported..
+        ///   Looks up a localized string similar to As a command-line option, the property type &apos;{0}&apos; is not supported..
         /// </summary>
         public static string DCL202_Message {
             get {
                 return ResourceManager.GetString("DCL202_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Not supported raw command-line argument type.
+        /// </summary>
+        public static string DCL203 {
+            get {
+                return ResourceManager.GetString("DCL203", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to To receive raw command-line arguments (typically string[]), you should also use the same property type string[] or the interface IReadOnlyList&lt;string&gt;..
+        /// </summary>
+        public static string DCL203_Description {
+            get {
+                return ResourceManager.GetString("DCL203_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to [RawArguments] can only be applied to properties of type string[] or IReadOnlyList&lt;string&gt;..
+        /// </summary>
+        public static string DCL203_Message {
+            get {
+                return ResourceManager.GetString("DCL203_Message", resourceCulture);
             }
         }
     }

--- a/src/DotNetCampus.CommandLine.Analyzer/Properties/Localizations.resx
+++ b/src/DotNetCampus.CommandLine.Analyzer/Properties/Localizations.resx
@@ -141,13 +141,13 @@
     <value>Use 'string' type instead</value>
   </data>
   <data name="DCL202_Description" xml:space="preserve">
-    <value>This property has the type '{0}' which is not built-in supported. It's recommended to use bool/string/IReadOnlyList&lt;string&gt; or other types that the code fix will suggest you change instead or add a custom converter on your Value or Option attribute.</value>
+    <value>As a command-line option, the property type '{0}' is not supported. It is recommended to use bool/string/IReadOnlyList&lt;string&gt; or another type that the code fix may suggest, or add a custom converter on your Value or Option attribute.</value>
   </data>
   <data name="DCL202_Message" xml:space="preserve">
-    <value>This property has the type '{0}' which is not built-in supported.</value>
+    <value>As a command-line option, the property type '{0}' is not supported.</value>
   </data>
   <data name="DCL202" xml:space="preserve">
-    <value>Not supported property type</value>
+    <value>Not supported command-line property type</value>
   </data>
   <data name="DCL101_Description" xml:space="preserve">
     <value>The command-line option definition names should be kebab-case, even though you can use any kind of style in the command line environment.</value>
@@ -169,5 +169,14 @@
   </data>
   <data name="DCL201" xml:space="preserve">
     <value>Recommended option property type</value>
+  </data>
+  <data name="DCL203" xml:space="preserve">
+    <value>Not supported raw command-line argument type</value>
+  </data>
+  <data name="DCL203_Message" xml:space="preserve">
+    <value>[RawArguments] can only be applied to properties of type string[] or IReadOnlyList&lt;string&gt;.</value>
+  </data>
+  <data name="DCL203_Description" xml:space="preserve">
+    <value>To receive raw command-line arguments (typically string[]), you should also use the same property type string[] or the interface IReadOnlyList&lt;string&gt;.</value>
   </data>
 </root>

--- a/src/DotNetCampus.CommandLine.Analyzer/Properties/Localizations.zh-hans.resx
+++ b/src/DotNetCampus.CommandLine.Analyzer/Properties/Localizations.zh-hans.resx
@@ -63,4 +63,13 @@
   <data name="DCL201" xml:space="preserve">
         <value>符合要求的命令行选项类型</value>
     </data>
+  <data name="DCL203" xml:space="preserve">
+    <value>不支持此类型的原始命令行参数</value>
+  </data>
+  <data name="DCL203_Message" xml:space="preserve">
+    <value>[RawArguments] 只能标记在 string[] 或 IReadOnlyList&lt;string&gt; 属性上。</value>
+  </data>
+  <data name="DCL203_Description" xml:space="preserve">
+    <value>要接收原始命令行参数（通常是 string[] 类型），你应该也使用相同的属性类型 string[] 或其接口 IReadOnlyList&lt;string&gt;。</value>
+  </data>
 </root>

--- a/src/DotNetCampus.CommandLine/CommandLineStyle.cs
+++ b/src/DotNetCampus.CommandLine/CommandLineStyle.cs
@@ -15,7 +15,7 @@ public enum CommandLineStyle
     /// 灵活风格是一种包容性最强的命令行参数风格，旨在让不熟悉命令行操作的用户也能轻松使用。它通过智能识别尝试理解用户输入的意图，支持多种参数格式共存。<br/>
     /// <br/>
     /// 详细规则：<br/>
-    /// 1. 参数前缀支持多种形式：双破折线(--), 单破折线(-), 斜杠(/)<br/>
+    /// 1. 参数前缀支持多种形式：双破折线(--), 单破折线(-), 斜杠(/，仅 Windows)<br/>
     /// 2. 参数值分隔符兼容多种形式：空格、等号(=)、冒号(:)<br/>
     /// 3. 参数命名风格兼容kebab-case(--parameter-name)、PascalCase(-ParameterName)和camelCase<br/>
     /// 4. 默认大小写不敏感，便于初学者使用<br/>
@@ -46,7 +46,7 @@ public enum CommandLineStyle
     /// app -p:value               # 短选项冒号分隔
     /// app -pvalue                # 短选项直接跟值（GNU风格）
     ///
-    /// # 斜杠选项（Windows风格）
+    /// # 斜杠选项（Windows风格，仅在 Windows 系统可用）
     /// app /parameter value       # 斜杠前缀长选项
     /// app /p value               # 斜杠前缀短选项
     /// app /parameter:value       # 斜杠前缀冒号分隔（类MSBuild）
@@ -151,7 +151,7 @@ public enum CommandLineStyle
     /// .NET CLI风格，使用冒号分隔参数：<br/>
     /// 1. 短选项形式为 -参数:值<br/>
     /// 2. 长选项可以是 --参数:值<br/>
-    /// 3. 也支持斜杠前缀 /参数:值
+    /// 3. 也支持斜杠前缀 /参数:值（仅 Windows 环境下可用）
     /// </summary>
     /// <remarks>
     /// 这种风格在现代.NET工具链（dotnet CLI、NuGet、MSBuild等）和其他Microsoft工具中广泛使用。<br/>
@@ -160,7 +160,7 @@ public enum CommandLineStyle
     /// 1. 支持使用冒号(:)作为选项和参数值的分隔符<br/>
     /// 2. 短选项以单破折线(-)开头，后跟选项名，然后是冒号和参数值<br/>
     /// 3. 长选项以双破折线(--)开头，后跟选项名，然后是冒号和参数值<br/>
-    /// 4. 也支持使用斜杠(/)作为选项前缀，特别是在Windows环境中<br/>
+    /// 4. 也支持使用斜杠(/)作为选项前缀，仅在Windows环境中可用<br/>
     /// 5. 参数名可以是单个字母、多字符缩写或完整的单词，支持各种命名规范<br/>
     /// 6. 布尔选项通常不需要值，或使用true/false、on/off等值<br/>
     /// 7. 多个短选项一般不支持合并（与GNU/POSIX不同）<br/>
@@ -185,7 +185,7 @@ public enum CommandLineStyle
     /// dotnet test --test-category:UnitTest     # kebab-case，双破折号
     /// dotnet run --projectName:App1            # camelCase，双破折号
     ///
-    /// # 斜杠前缀(Windows风格)
+    /// # 斜杠选项（Windows风格，仅在 Windows 系统可用）
     /// msbuild /p:Configuration=Release  # MSBuild属性
     /// dotnet test /blame                # 启用故障分析
     /// dotnet nuget push /source:feed    # 指定源

--- a/src/DotNetCampus.CommandLine/Compiler/RawArgumentsAttribute.cs
+++ b/src/DotNetCampus.CommandLine/Compiler/RawArgumentsAttribute.cs
@@ -1,0 +1,9 @@
+namespace DotNetCampus.Cli.Compiler;
+
+/// <summary>
+/// 标记在一个 string[] 或 IReadOnlyList&lt;string&gt; 类型的属性上，表示此属性将接收保留的原始命令行参数。
+/// </summary>
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+public sealed class RawArgumentsAttribute : CommandLineAttribute
+{
+}

--- a/src/DotNetCampus.CommandLine/Utils/Parsers/DotNetStyleParser.cs
+++ b/src/DotNetCampus.CommandLine/Utils/Parsers/DotNetStyleParser.cs
@@ -105,8 +105,11 @@ internal readonly ref struct DotNetArgument(DotNetParsedType type)
     public static DotNetArgument Parse(string argument, DotNetParsedType lastType)
     {
         var isPostPositionalArgument = lastType is DotNetParsedType.PositionalArgumentSeparator or DotNetParsedType.PostPositionalArgument;
+        var hasPrefix = OperatingSystem.IsWindows()
+            ? argument.Length > 0 && (argument[0] is '-' or '/')
+            : argument.Length > 0 && argument[0] is '-';
 
-        if (!isPostPositionalArgument && argument is ['-', ..] or ['/', ..])
+        if (!isPostPositionalArgument && hasPrefix)
         {
             if (argument.Length is 1)
             {

--- a/src/DotNetCampus.CommandLine/Utils/Parsers/FlexibleStyleParser.cs
+++ b/src/DotNetCampus.CommandLine/Utils/Parsers/FlexibleStyleParser.cs
@@ -106,8 +106,11 @@ internal readonly ref struct FlexibleArgument(FlexibleParsedType type)
     public static FlexibleArgument Parse(string argument, FlexibleParsedType lastType)
     {
         var isPostPositionalArgument = lastType is FlexibleParsedType.PositionalArgumentSeparator or FlexibleParsedType.PostPositionalArgument;
+        var hasPrefix = OperatingSystem.IsWindows()
+            ? argument.Length > 0 && (argument[0] is '-' or '/')
+            : argument.Length > 0 && argument[0] is '-';
 
-        if (!isPostPositionalArgument && argument is ['-', ..] or ['/', ..])
+        if (!isPostPositionalArgument && hasPrefix)
         {
             if (argument.Length is 1)
             {


### PR DESCRIPTION
生成的类型预览：

```csharp
#nullable enable
namespace DotNetCampus.Cli;

/// <summary>
/// 辅助 <see cref="global::DotNetCampus.Cli.DefaultOptions"/> 生成命令行选项、谓词或处理函数的创建。
/// </summary>
internal sealed class DefaultOptionsBuilder
{
    public static object CreateInstance(global::DotNetCampus.Cli.CommandLine commandLine)
    {
        var caseSensitive = commandLine.DefaultCaseSensitive;
        var result = new global::DotNetCampus.Cli.DefaultOptions
        {
            // 1. [RawArguments]
            MainArgs = (string[])commandLine.CommandLineArguments,

            // 2. [Option]
            // There is no option to be initialized.

            // 3. [Value]
            // There is no positional argument to be initialized.
        };

        // 1. [RawArguments]
        // result.MainArgs = commandLine.CommandLineArguments;

        // 2. [Option]
        if (commandLine.GetOption("default-text") is { } o0)
        {
            result.DefaultText = o0;
        }
        if (commandLine.GetOption("default-directory") is { } o1)
        {
            result.DefaultDirectory = o1;
        }

        // 3. [Value]
        // There is no positional argument to be assigned.

        return result;
    }
}
```