### PR TITLE
默认忽略未知选项（仍然要求不可忽略未知位置参数）

### DIFF
--- a/src/DotNetCampus.CommandLine/CommandLineParsingOptions.cs
+++ b/src/DotNetCampus.CommandLine/CommandLineParsingOptions.cs
@@ -6,19 +6,39 @@ namespace DotNetCampus.Cli;
 public readonly record struct CommandLineParsingOptions
 {
     /// <inheritdoc cref="CommandLineStyle.Flexible" />
-    public static CommandLineParsingOptions Flexible => new() { Style = CommandLineStyle.Flexible };
+    public static CommandLineParsingOptions Flexible => new()
+    {
+        Style = CommandLineStyle.Flexible,
+        UnknownArgumentsHandling = UnknownCommandArgumentHandling.IgnoreUnknownOptionalArguments,
+    };
 
     /// <inheritdoc cref="CommandLineStyle.DotNet" />
-    public static CommandLineParsingOptions DotNet => new() { Style = CommandLineStyle.DotNet };
+    public static CommandLineParsingOptions DotNet => new()
+    {
+        Style = CommandLineStyle.DotNet,
+        UnknownArgumentsHandling = UnknownCommandArgumentHandling.IgnoreUnknownOptionalArguments,
+    };
 
     /// <inheritdoc cref="CommandLineStyle.Gnu" />
-    public static CommandLineParsingOptions Gnu => new() { Style = CommandLineStyle.Gnu };
+    public static CommandLineParsingOptions Gnu => new()
+    {
+        Style = CommandLineStyle.Gnu,
+        UnknownArgumentsHandling = UnknownCommandArgumentHandling.IgnoreUnknownOptionalArguments,
+    };
 
     /// <inheritdoc cref="CommandLineStyle.Posix" />
-    public static CommandLineParsingOptions Posix => new() { Style = CommandLineStyle.Posix };
+    public static CommandLineParsingOptions Posix => new()
+    {
+        Style = CommandLineStyle.Posix,
+        UnknownArgumentsHandling = UnknownCommandArgumentHandling.IgnoreUnknownOptionalArguments,
+    };
 
     /// <inheritdoc cref="CommandLineStyle.Windows" />
-    public static CommandLineParsingOptions Windows => new() { Style = CommandLineStyle.Windows };
+    public static CommandLineParsingOptions Windows => new()
+    {
+        Style = CommandLineStyle.Windows,
+        UnknownArgumentsHandling = UnknownCommandArgumentHandling.IgnoreUnknownOptionalArguments,
+    };
 
     /// <inheritdoc cref="CommandLineStyle.Windows" />
     [Obsolete("为避免理解歧义，已弃用此名称，请使用 Windows 代替。")]

--- a/tests/DotNetCampus.CommandLine.Tests/CommandLineStyleTestingExtensions.cs
+++ b/tests/DotNetCampus.CommandLine.Tests/CommandLineStyleTestingExtensions.cs
@@ -2,16 +2,22 @@ using System;
 
 namespace DotNetCampus.Cli.Tests;
 
+using UH = UnknownCommandArgumentHandling;
+
 internal static class CommandLineStyleTestingExtensions
 {
     public static CommandLineParsingOptions ToParsingOptions(this TestCommandLineStyle style) => style switch
     {
-        TestCommandLineStyle.Flexible => CommandLineParsingOptions.Flexible,
-        TestCommandLineStyle.DotNet => CommandLineParsingOptions.DotNet,
-        TestCommandLineStyle.Gnu => CommandLineParsingOptions.Gnu,
-        TestCommandLineStyle.Posix => CommandLineParsingOptions.Posix,
-        TestCommandLineStyle.Windows => CommandLineParsingOptions.Windows,
-        TestCommandLineStyle.Url => CommandLineParsingOptions.Flexible with { SchemeNames = ["test"] },
+        TestCommandLineStyle.Flexible => CommandLineParsingOptions.Flexible with { UnknownArgumentsHandling = UH.AllArgumentsMustBeRecognized },
+        TestCommandLineStyle.DotNet => CommandLineParsingOptions.DotNet with { UnknownArgumentsHandling = UH.AllArgumentsMustBeRecognized },
+        TestCommandLineStyle.Gnu => CommandLineParsingOptions.Gnu with { UnknownArgumentsHandling = UH.AllArgumentsMustBeRecognized },
+        TestCommandLineStyle.Posix => CommandLineParsingOptions.Posix with { UnknownArgumentsHandling = UH.AllArgumentsMustBeRecognized },
+        TestCommandLineStyle.Windows => CommandLineParsingOptions.Windows with { UnknownArgumentsHandling = UH.AllArgumentsMustBeRecognized },
+        TestCommandLineStyle.Url => CommandLineParsingOptions.Flexible with
+        {
+            SchemeNames = ["test"],
+            UnknownArgumentsHandling = UH.AllArgumentsMustBeRecognized,
+        },
         _ => throw new ArgumentOutOfRangeException(nameof(style), style, null),
     };
 }


### PR DESCRIPTION
如果我们对使用命令行库的应用进行分类，有以下三类：

1. 面向普通用户的 GUI 程序
2. 面向专业人士的 TUI 程序
3. 设计为被其他应用集成或调用的程序

对于 1 来说，如果严格解析命令行参数，很容易出现用户启动无反应的情况；但究竟该不该忽略还有待商榷。  
对于 2 来说，最好是严格解析，对于不支持的选项和位置参数报错。

但对于 3 就不一样了，由于被其他应用集成，所以调用本程序的都是提前写好的程序。各个不同应用的版本升级节奏都不一样，当增加选项增加新功能时，中间会存在某段时间旧版本在接受新传入命令行选项的情况。对开发人员来说还好，但对终端用户来说就难以接受了。

考虑到不看文档的开发人员更容易遇到开发用户端产品，并使之被其他软件调用的情况，我决定让默认行为照顾这些不看文档的开发人员，即忽略未知选项。而看文档的开发人员可以主动将其改为严格模式，确保在遇到未知选项时能正确报错。